### PR TITLE
Fixing Facebook Auth for permissions

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
+
+    testCompile 'org.robolectric:robolectric:3.1.1'
+    testCompile 'org.robolectric:shadows-support-v4:3.1.1'
 }
 
 android.libraryVariants.all { variant ->

--- a/library/src/main/java/com/parse/FacebookController.java
+++ b/library/src/main/java/com/parse/FacebookController.java
@@ -24,9 +24,12 @@ import com.facebook.login.LoginResult;
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
+import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.SimpleTimeZone;
 
 import bolts.Task;
@@ -48,6 +51,8 @@ import bolts.Task;
   private static final String KEY_USER_ID = "id";
   private static final String KEY_ACCESS_TOKEN = "access_token";
   private static final String KEY_EXPIRATION_DATE = "expiration_date";
+  private static final String KEY_REFRESH_DATE = "last_refresh_date";
+  private static final String KEY_PERMISSIONS = "permissions";
 
   // Mirrors com.facebook.internal.LoginAuthorizationType.java
   public enum LoginAuthorizationType {
@@ -131,11 +136,37 @@ import bolts.Task;
     return tcs.getTask();
   }
 
+  /**
+   * Get auth data from the access token.
+   * Includes the following:
+   * - UserId
+   * - Access Token
+   * - Expiration Date
+   * - Last Refresh Date
+   * - Permissions (Comma Delineated)
+   * @param accessToken - Facebook's {@link AccessToken}
+   * @return - {@link Map} of auth data used parse to create facebook {@link AccessToken} by hand.
+   * See {@link FacebookController#setAuthData(Map)}
+   */
   public Map<String, String> getAuthData(AccessToken accessToken) {
     Map<String, String> authData = new HashMap<>();
     authData.put(KEY_USER_ID, accessToken.getUserId());
     authData.put(KEY_ACCESS_TOKEN, accessToken.getToken());
     authData.put(KEY_EXPIRATION_DATE, PRECISE_DATE_FORMAT.format(accessToken.getExpires()));
+    authData.put(KEY_REFRESH_DATE, PRECISE_DATE_FORMAT.format(accessToken.getLastRefresh()));
+
+    Set<String> permissionSet = accessToken.getPermissions();
+    StringBuilder stringBuilder = new StringBuilder();
+    for (String permission : permissionSet) {
+      stringBuilder.append(permission);
+      stringBuilder.append(",");
+    }
+    if (stringBuilder.length() > 0) {
+      stringBuilder.deleteCharAt(stringBuilder.length() - 1);
+    }
+    String valueToInsert = stringBuilder.toString();
+    authData.put(KEY_PERMISSIONS, valueToInsert);
+
     return authData;
   }
 
@@ -148,23 +179,44 @@ import bolts.Task;
 
     String token = authData.get(KEY_ACCESS_TOKEN);
     String userId = authData.get(KEY_USER_ID);
+    Date lastRefreshDate = PRECISE_DATE_FORMAT.parse(authData.get(KEY_REFRESH_DATE));
 
     AccessToken currentAccessToken = facebookSdkDelegate.getCurrentAccessToken();
     if (currentAccessToken != null) {
       String currToken = currentAccessToken.getToken();
       String currUserId = currentAccessToken.getUserId();
+      Date currLastRefreshDate = currentAccessToken.getLastRefresh();
+
       if (currToken != null && currToken.equals(token)
           && currUserId != null && currUserId.equals(userId)) {
         // Don't reset the current token if it's the same. If we reset it every time we'd lose
         // permissions, source, lastRefreshTime, etc.
         return;
       }
+
+      //Don't reset if facebook sdk auth token is newer than what is cached by parse. Trust FB.
+      if (currLastRefreshDate != null
+              && currLastRefreshDate.after(lastRefreshDate)){
+        return;
+      }
     }
+
+    //Don't forget permissions....if available
+    String permissionsCommaDelineated = authData.get(KEY_PERMISSIONS);
+    Set<String> permissions = null;
+    if (permissionsCommaDelineated != null && !permissionsCommaDelineated.isEmpty()) {
+      String permissionsArray[] = permissionsCommaDelineated.split(",");
+      permissions = new HashSet<>();
+      for (int i = 0; i < permissionsArray.length; i++) {
+        permissions.add(permissionsArray[i]);
+      }
+    }
+
     AccessToken accessToken = new AccessToken(
         token,
         facebookSdkDelegate.getApplicationId(),
         userId,
-        null,
+        permissions,
         null,
         null,
         PRECISE_DATE_FORMAT.parse(authData.get(KEY_EXPIRATION_DATE)),

--- a/library/src/main/java/com/parse/FacebookController.java
+++ b/library/src/main/java/com/parse/FacebookController.java
@@ -12,6 +12,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.support.v4.app.Fragment;
+import android.text.TextUtils;
 
 import com.facebook.AccessToken;
 import com.facebook.CallbackManager;
@@ -156,15 +157,7 @@ import bolts.Task;
     authData.put(KEY_REFRESH_DATE, PRECISE_DATE_FORMAT.format(accessToken.getLastRefresh()));
 
     Set<String> permissionSet = accessToken.getPermissions();
-    StringBuilder stringBuilder = new StringBuilder();
-    for (String permission : permissionSet) {
-      stringBuilder.append(permission);
-      stringBuilder.append(",");
-    }
-    if (stringBuilder.length() > 0) {
-      stringBuilder.deleteCharAt(stringBuilder.length() - 1);
-    }
-    String valueToInsert = stringBuilder.toString();
+    String valueToInsert = TextUtils.join(",", permissionSet);
     authData.put(KEY_PERMISSIONS, valueToInsert);
 
     return authData;

--- a/library/src/test/java/com/parse/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/FacebookControllerTest.java
@@ -22,7 +22,9 @@ import com.facebook.login.LoginResult;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
+import org.robolectric.RobolectricTestRunner;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -49,6 +51,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@RunWith(RobolectricTestRunner.class)
 public class FacebookControllerTest {
 
   private Locale defaultLocale;

--- a/library/src/test/java/com/parse/ParseFacebookUtilsTest.java
+++ b/library/src/test/java/com/parse/ParseFacebookUtilsTest.java
@@ -21,7 +21,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
+import org.robolectric.RobolectricTestRunner;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -45,7 +47,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(MockitoJUnitRunner.class)
+@RunWith(RobolectricTestRunner.class)
 public class ParseFacebookUtilsTest {
 
   @Mock
@@ -55,8 +57,10 @@ public class ParseFacebookUtilsTest {
 
   @Before
   public void setUp() {
+    MockitoAnnotations.initMocks(this);
     ParseFacebookUtils.controller = controller;
     ParseFacebookUtils.userDelegate = userDelegate;
+
   }
 
   @After


### PR DESCRIPTION
# Problem
When logging into facebook using parse in order to update facebook AccessToken permissions, the AccessToken permissions get set to 0. 

# Steps to reproduce

1.  Log into facebook using parse. Request "user_friends". Accept the permission.
2. Remove "user_friends" permission from facebook app settings under your user. (Use browser)
3. Have app log into facebook for read permission using parse. Get AccessToken. Watch permissions go to 0. 

# Solution
The solution was to write the permissions to facebook AccessToken any time they were available. This code was missing. I also added checks for last refresh. If you choose to login into parse using facebook auth, don't overwrite the facebook auth if the parse auth is OLDER. 

# Testing
Test was added to check for permissions when passing them through FacebookController. 