### PR TITLE
UPDATE LIBS: Update Parse, Facebook and Bolts libraries

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -27,7 +27,7 @@ android {
     buildToolsVersion "25.0.2"
 
     defaultConfig {
-        minSdkVersion 9
+        minSdkVersion 15
         targetSdkVersion 25
         versionCode 1
         versionName project.version
@@ -35,15 +35,15 @@ android {
 }
 
 dependencies {
-    compile 'com.parse:parse-android:1.12.0'
+    compile 'com.parse:parse-android:1.15.8'
 
     // We need to exclude bolts-android since facebook-android-sdk 4.x.x depends on a version of
     // bolts-android before being split into bolts-tasks and bolts-applinks.
-    compile ('com.facebook.android:facebook-android-sdk:4.4.0') {
+    compile ('com.facebook.android:facebook-android-sdk:4.24.0') {
         exclude module: 'bolts-android'
     }
     // facebook-android-sdk 4.x.x depends on AppLinks inside bolts-android
-    compile 'com.parse.bolts:bolts-applinks:1.3.0'
+    compile 'com.parse.bolts:bolts-applinks:1.4.0'
 
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
This Pull request upgrades the following libraries
- *Parse* 1.12.0 -> 1.15.8
- *Facebook* 4.4.0 -> 4.24.0 (Uses the Graph API Version [2.9](https://github.com/facebook/facebook-android-sdk/blob/master/facebook/src/main/java/com/facebook/internal/ServerProtocol.java#L79))
- *Bolts* 1.3.0 -> 1.4.0

**NOTE:** `minSdkVersion` also changed from `9` to `15` because the facebook library `minSdkVersion` is `15`.

Please help me to review and merge.

Thank you.