### PR TITLE
prevent asymmetric facebook session management with flag

### DIFF
--- a/library/src/main/java/com/parse/FacebookController.java
+++ b/library/src/main/java/com/parse/FacebookController.java
@@ -139,9 +139,9 @@ import bolts.Task;
     return authData;
   }
 
-  public void setAuthData(Map<String, String> authData)
+  public void setAuthData(Map<String, String> authData, boolean isFacebookLoginScopeExternallyManaged)
       throws java.text.ParseException {
-    if (authData == null) {
+    if (authData == null && !isFacebookLoginScopeExternallyManaged) {
       facebookSdkDelegate.getLoginManager().logOut();
       return;
     }

--- a/library/src/main/java/com/parse/ParseFacebookUtils.java
+++ b/library/src/main/java/com/parse/ParseFacebookUtils.java
@@ -71,6 +71,7 @@ public final class ParseFacebookUtils {
 
   private static final Object lock = new Object();
   /* package for tests */ static boolean isInitialized;
+  /* package for tests */ static boolean isFacebookLoginScopeExternallyManaged = false;
   /* package for tests */ static FacebookController controller;
   /* package for tests */ static ParseUserDelegate userDelegate = new ParseUserDelegateImpl();
 
@@ -111,7 +112,7 @@ public final class ParseFacebookUtils {
         @Override
         public boolean onRestore(Map<String, String> authData) {
           try {
-            getController().setAuthData(authData);
+            getController().setAuthData(authData, isFacebookLoginScopeExternallyManaged);
             return true;
           } catch (Exception e) {
             return false;
@@ -167,6 +168,7 @@ public final class ParseFacebookUtils {
    * @return A task that will be resolved when logging in is complete.
    */
   public static Task<ParseUser> logInInBackground(AccessToken accessToken) {
+    isFacebookLoginScopeExternallyManaged = true;
     checkInitialization();
     return userDelegate.logInWithInBackground(AUTH_TYPE, getController().getAuthData(accessToken));
   }
@@ -180,6 +182,7 @@ public final class ParseFacebookUtils {
    * @return A task that will be resolved when logging in is complete.
    */
   public static Task<ParseUser> logInInBackground(AccessToken accessToken, LogInCallback callback) {
+    isFacebookLoginScopeExternallyManaged = true;
     return callbackOnMainThreadAsync(logInInBackground(accessToken), callback, true);
   }
 

--- a/library/src/test/java/com/parse/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/FacebookControllerTest.java
@@ -102,17 +102,31 @@ public class FacebookControllerTest {
   //region testSetAuthData
 
   @Test
-  public void testSetAuthDataWithNull() throws java.text.ParseException {
+  public void testSetAuthDataWithNullNotExternallyManaged() throws java.text.ParseException {
     FacebookController.FacebookSdkDelegate facebookSdk =
         mock(FacebookController.FacebookSdkDelegate.class);
     LoginManager loginManager = mock(LoginManager.class);
     when(facebookSdk.getLoginManager()).thenReturn(loginManager);
     FacebookController controller = new FacebookController(facebookSdk);
 
-    controller.setAuthData(null);
+    controller.setAuthData(null, true);
     verify(facebookSdk).getLoginManager();
     verifyNoMoreInteractions(facebookSdk);
     verify(loginManager).logOut();
+    verifyNoMoreInteractions(loginManager);
+  }
+
+  @Test
+  public void testSetAuthDataWithNullExternallyManaged() throws java.text.ParseException {
+    FacebookController.FacebookSdkDelegate facebookSdk =
+            mock(FacebookController.FacebookSdkDelegate.class);
+    LoginManager loginManager = mock(LoginManager.class);
+    when(facebookSdk.getLoginManager()).thenReturn(loginManager);
+    FacebookController controller = new FacebookController(facebookSdk);
+
+    controller.setAuthData(null, false);
+    verify(facebookSdk).getLoginManager();
+    verifyNoMoreInteractions(facebookSdk);
     verifyNoMoreInteractions(loginManager);
   }
 
@@ -130,7 +144,7 @@ public class FacebookControllerTest {
     authData.put("id", "test_id");
     authData.put("access_token", "test_token");
     authData.put("expiration_date", "2015-07-03T07:00:00.000Z");
-    controller.setAuthData(authData);
+    controller.setAuthData(authData, true);
     ArgumentCaptor<AccessToken> accessTokenCapture = ArgumentCaptor.forClass(AccessToken.class);
     verify(facebookSdk).setCurrentAccessToken(accessTokenCapture.capture());
     AccessToken accessToken = accessTokenCapture.getValue();
@@ -153,13 +167,13 @@ public class FacebookControllerTest {
     authData.put("id", "new_id");
     authData.put("access_token", "test_token");
     authData.put("expiration_date", "2015-07-03T07:00:00.000Z");
-    controller.setAuthData(authData);
+    controller.setAuthData(authData, true);
     verify(facebookSdk, times(1)).setCurrentAccessToken(any(AccessToken.class));
 
     authData.put("id", "new_id");
     authData.put("access_token", "new_token");
     authData.put("expiration_date", "2015-07-03T07:00:00.000Z");
-    controller.setAuthData(authData);
+    controller.setAuthData(authData, true);
     verify(facebookSdk, times(2)).setCurrentAccessToken(any(AccessToken.class));
   }
 
@@ -175,7 +189,7 @@ public class FacebookControllerTest {
     authData.put("id", "test_id");
     authData.put("access_token", "test_token");
     authData.put("expiration_date", "2015-07-03T07:00:00.000Z");
-    controller.setAuthData(authData);
+    controller.setAuthData(authData, true);
     verify(facebookSdk, never()).setCurrentAccessToken(any(AccessToken.class));
   }
 

--- a/library/src/test/java/com/parse/ParseFacebookUtilsTest.java
+++ b/library/src/test/java/com/parse/ParseFacebookUtilsTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Matchers.anyMapOf;
@@ -102,7 +103,7 @@ public class ParseFacebookUtilsTest {
     Map<String, String> authData = new HashMap<>();
 
     assertTrue(callback.onRestore(authData));
-    verify(controller).setAuthData(authData);
+    verify(controller).setAuthData(authData, true);
   }
 
   @Test
@@ -115,10 +116,10 @@ public class ParseFacebookUtilsTest {
     Map<String, String> authData = new HashMap<>();
     doThrow(new RuntimeException())
         .when(controller)
-        .setAuthData(anyMapOf(String.class, String.class));
+        .setAuthData(anyMapOf(String.class, String.class), anyBoolean());
 
     assertFalse(callback.onRestore(authData));
-    verify(controller).setAuthData(authData);
+    verify(controller).setAuthData(authData, false);
   }
 
   //endregion


### PR DESCRIPTION
I was running into the following issue:

I was acquiring my facebook accessToken and then linking with `ParseFacebookUtils.linkInBackground(...)`. Then, if I had already linked with that Facebook, I was getting a 208 code. In that case, I then have to use `ParseFacebookUtils.logInInBackground(...)` to retrieve that old linked ParseUser. The problem is, logInInBackground will log me out of Facebook, even though I'm supplying my own accessToken.

Logic tells me, that if I'm supplying my own accessToken, its unnecessary for it to assume its managing the lifecycle of my accessToken. 

My Solution: I added a flag to track the cases where the accessToken is acquired/expired externally to stop it from thinking it has to log you out.