### PR TITLE
Fix error parsing process for date fail because of getting null

### DIFF
--- a/library/src/main/java/com/parse/FacebookController.java
+++ b/library/src/main/java/com/parse/FacebookController.java
@@ -175,7 +175,12 @@ import bolts.Task;
 
     String token = authData.get(KEY_ACCESS_TOKEN);
     String userId = authData.get(KEY_USER_ID);
-    Date lastRefreshDate = parseDateString(authData.get(KEY_REFRESH_DATE));
+    String lastRefreshDateString = authData.get(KEY_REFRESH_DATE);
+
+    Date lastRefreshDate = null;
+    if (lastRefreshDateString != null) {
+      lastRefreshDate = parseDateString(lastRefreshDateString);
+    }
 
     AccessToken currentAccessToken = facebookSdkDelegate.getCurrentAccessToken();
     if (currentAccessToken != null) {
@@ -192,6 +197,7 @@ import bolts.Task;
 
       //Don't reset if facebook sdk auth token is newer than what is cached by parse. Trust FB.
       if (currLastRefreshDate != null
+              && lastRefreshDate != null
               && currLastRefreshDate.after(lastRefreshDate)){
         return;
       }

--- a/library/src/test/java/com/parse/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/FacebookControllerTest.java
@@ -235,6 +235,30 @@ public class FacebookControllerTest {
     assertEquals("test_application_id", accessToken.getApplicationId());
   }
 
+  @Test
+  public void testSetAuthDataWithNoRefreshDate() throws ParseException {
+    Locale.setDefault(new Locale("ar")); // Mimic the device's locale
+    TimeZone.setDefault(TimeZone.getTimeZone("PST"));
+
+    FacebookController.FacebookSdkDelegate facebookSdk =
+            mock(FacebookController.FacebookSdkDelegate.class);
+    when(facebookSdk.getApplicationId()).thenReturn("test_application_id");
+    FacebookController controller = new FacebookController(facebookSdk);
+
+    Map<String, String> authData = new HashMap<>();
+    authData.put("id", "test_id");
+    authData.put("access_token", "test_token");
+    authData.put("expiration_date", "2015-07-03T07:00:00Z");
+    controller.setAuthData(authData);
+    ArgumentCaptor<AccessToken> accessTokenCapture = ArgumentCaptor.forClass(AccessToken.class);
+    verify(facebookSdk).setCurrentAccessToken(accessTokenCapture.capture());
+    AccessToken accessToken = accessTokenCapture.getValue();
+    assertEquals("test_id", accessToken.getUserId());
+    assertEquals("test_token", accessToken.getToken());
+    assertEquals(new GregorianCalendar(2015, 6, 3).getTime(), accessToken.getExpires());
+    assertEquals("test_application_id", accessToken.getApplicationId());
+  }
+
   //endregion
 
   //region testAuthenticateAsync


### PR DESCRIPTION
related to #34 

I found another problem that [authData.get(KEY_REFRESH_DATE)](https://github.com/parse-community/ParseFacebookUtils-Android/blob/master/library/src/main/java/com/parse/FacebookController.java#L178) sometimes return null in case of login for facebook with another platform's sdk.

In my case, NPE had been thrown since `authData` didn't have `"last_refresh_date"`.

So, I added null checking.

About former issue #34 , I confirmed the problem was solved by this fixing.

Thanks.