### PR TITLE
Pass null for newly required dataAccessExpirationTime

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 before_install:
     - pip install --user codecov
     - mkdir "$ANDROID_HOME/licenses" || true
-    - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+    - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
 
 script:
   - ./gradlew clean testDebugUnitTest jacocoTestReport --info

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
 dependencies {
     api 'com.parse:parse-android:1.17.3'
 
-    api 'com.facebook.android:facebook-android-sdk:4.34.0'
+    api 'com.facebook.android:facebook-android-sdk:4.40.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/library/src/main/java/com/parse/facebook/FacebookController.java
+++ b/library/src/main/java/com/parse/facebook/FacebookController.java
@@ -220,7 +220,7 @@ class FacebookController {
         null,
         null,
         parseDateString(authData.get(KEY_EXPIRATION_DATE)),
-        null);
+        null, null);
     facebookSdkDelegate.setCurrentAccessToken(accessToken);
   }
 

--- a/library/src/test/java/com/parse/facebook/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/facebook/FacebookControllerTest.java
@@ -100,7 +100,7 @@ public class FacebookControllerTest {
         null,
         null,
         calendar.getTime(),
-        null);
+        null, null);
 
     Map<String, String> authData = controller.getAuthData(accessToken);
     assertEquals("user_id", authData.get("id"));

--- a/library/src/test/java/com/parse/facebook/TestUtils.java
+++ b/library/src/test/java/com/parse/facebook/TestUtils.java
@@ -20,6 +20,7 @@ import com.facebook.AccessToken;
         null,
         null,
         null,
-        null);
+        null,
+            null);
   }
 }


### PR DESCRIPTION
If you look at the constructor for `AccessToken`:
```
@param dataAccessExpirationTime The time when user data access expires
```
and if a null value is passed:
```
this.dataAccessExpirationTime =
                dataAccessExpirationTime != null && dataAccessExpirationTime.getTime() != 0
                    ? dataAccessExpirationTime
                    : DEFAULT_EXPIRATION_TIME;
```
where `DEFAULT_EXPIRATION_TIME = new Date(Long.MAX_VALUE)`

This will fix https://github.com/parse-community/ParseFacebookUtils-Android/issues/46