### PR TITLE
Support facebook-android-sdk >= 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,14 +4,14 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
-        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.2'
+        classpath 'com.android.tools.build:gradle:3.4.1'
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.8.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }
 
 plugins {
-    id 'com.github.ben-manes.versions' version '0.20.0'
+    id 'com.github.ben-manes.versions' version '0.21.0'
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed May 30 23:22:49 PDT 2018
+#Sun May 26 12:48:07 IDT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
 dependencies {
     api "com.github.parse-community.Parse-SDK-Android:parse:1.19.0"
 
-    api 'com.facebook.android:facebook-android-sdk:4.40.0'
+    api 'com.facebook.android:facebook-android-sdk:5.1.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,7 +12,7 @@ android {
 }
 
 dependencies {
-    api "com.github.parse-community.Parse-SDK-Android:parse:1.19.0"
+    api "com.github.parse-community.Parse-SDK-Android:parse:1.20.0"
 
     api 'com.facebook.android:facebook-android-sdk:5.1.0'
 

--- a/library/src/main/java/com/parse/facebook/FacebookController.java
+++ b/library/src/main/java/com/parse/facebook/FacebookController.java
@@ -15,6 +15,7 @@ import android.support.v4.app.Fragment;
 import android.text.TextUtils;
 
 import com.facebook.AccessToken;
+import com.facebook.AccessTokenSource;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -221,6 +222,7 @@ class FacebookController {
                 permissions,
                 null,
                 null,
+                AccessTokenSource.DEVICE_AUTH,
                 parseDateString(authData.get(KEY_EXPIRATION_DATE)),
                 null, null);
         facebookSdkDelegate.setCurrentAccessToken(accessToken);

--- a/library/src/test/java/com/parse/facebook/FacebookControllerTest.java
+++ b/library/src/test/java/com/parse/facebook/FacebookControllerTest.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.support.v4.app.Fragment;
 
 import com.facebook.AccessToken;
+import com.facebook.AccessTokenSource;
 import com.facebook.CallbackManager;
 import com.facebook.FacebookCallback;
 import com.facebook.FacebookException;
@@ -25,6 +26,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -51,6 +53,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+@Config(manifest=Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class FacebookControllerTest {
 
@@ -99,6 +102,7 @@ public class FacebookControllerTest {
                 permissions,
                 null,
                 null,
+                AccessTokenSource.DEVICE_AUTH,
                 calendar.getTime(),
                 null, null);
 

--- a/library/src/test/java/com/parse/facebook/ParseFacebookUtilsTest.java
+++ b/library/src/test/java/com/parse/facebook/ParseFacebookUtilsTest.java
@@ -25,6 +25,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
 
 import java.util.Collection;
 import java.util.HashMap;
@@ -48,6 +49,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+@Config(manifest=Config.NONE)
 @RunWith(RobolectricTestRunner.class)
 public class ParseFacebookUtilsTest {
 

--- a/library/src/test/java/com/parse/facebook/TestUtils.java
+++ b/library/src/test/java/com/parse/facebook/TestUtils.java
@@ -9,12 +9,13 @@
 package com.parse.facebook;
 
 import com.facebook.AccessToken;
+import com.facebook.AccessTokenSource;
 
 /**
  * package
  */
 class TestUtils {
-    public static AccessToken newAccessToken() {
+    static AccessToken newAccessToken() {
         return new AccessToken(
                 "test_token",
                 "test_application_id",
@@ -22,6 +23,7 @@ class TestUtils {
                 null,
                 null,
                 null,
+                AccessTokenSource.DEVICE_AUTH,
                 null,
                 null,
                 null


### PR DESCRIPTION
The constructor parameters for AccessToken have changed in version 5.x of the Facebook SDK.