### PR TITLE
Only pull facebook-login dependency

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -14,7 +14,7 @@ android {
 dependencies {
     api "com.github.parse-community.Parse-SDK-Android:parse:1.20.0"
 
-    api 'com.facebook.android:facebook-android-sdk:5.1.0'
+    api 'com.facebook.android:facebook-login:5.1.0'
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:1.10.19'


### PR DESCRIPTION
Currently the lib is adding a dependency to the whole facebook SDK which can be quite large.

This lib only needs the facebook-login part.